### PR TITLE
Adiciona authenticação por token jwt e spring security + ajustes menores

### DIFF
--- a/backend/errorcenter/pom.xml
+++ b/backend/errorcenter/pom.xml
@@ -48,6 +48,28 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.10.7</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.10.7</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.10.7</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/configs/CorsConfig.java
+++ b/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/configs/CorsConfig.java
@@ -1,0 +1,27 @@
+package br.com.codenation.errorcenter.configs;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public FilterRegistrationBean corsFilter() {
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowCredentials(true);
+        config.addAllowedOrigin("*");
+        config.addAllowedHeader("*");
+        config.addAllowedMethod("*");
+        source.registerCorsConfiguration("/**", config);
+
+        FilterRegistrationBean bean = new FilterRegistrationBean(new CorsFilter(source));
+        bean.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return bean;
+    }
+}

--- a/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/controller/LogController.java
+++ b/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/controller/LogController.java
@@ -1,5 +1,27 @@
 package br.com.codenation.errorcenter.controller;
 
-public class LogController {
+import br.com.codenation.errorcenter.service.LogService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@CrossOrigin(origins = "*")
+@RequestMapping("/logs")
+public class LogController {
+    @Autowired
+    private LogService logService;
+
+    @GetMapping
+    public ResponseEntity<?> getLogs(HttpServletRequest request) throws Exception {
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getLogById(HttpServletRequest request, @PathVariable("id") String id) throws Exception {
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/controller/UserController.java
+++ b/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/controller/UserController.java
@@ -1,10 +1,16 @@
 package br.com.codenation.errorcenter.controller;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
+import br.com.codenation.errorcenter.dtos.LoggedUserDto;
+import br.com.codenation.errorcenter.dtos.UserLoginRequestBody;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.util.Pair;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +18,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import br.com.codenation.errorcenter.models.User;
 import br.com.codenation.errorcenter.service.UserService;
+
+import javax.servlet.http.HttpServletResponse;
 
 @RestController
 @RequestMapping("/user")
@@ -27,15 +35,22 @@ public class UserController {
 	}
 	
 	@PostMapping("/login")
-	public ResponseEntity<?> login(@RequestBody String email, @RequestBody String password) {
-		Optional<User> user = userService.login(password, email);
-		
-		if (user.isPresent()) {
-			return ResponseEntity.ok(user);
+	public ResponseEntity<?> login(@RequestBody UserLoginRequestBody body, HttpServletResponse response) {
+		try {
+			String email = body.email;
+			String password = body.password;
+
+			Pair<String, User> authResponse = userService.authenticateUser(email, password);
+			User user = authResponse.getSecond();
+			LoggedUserDto formattedUser = new LoggedUserDto(user.getId(), user.getName(), user.getEmail(), user.getTokenAccess());
+
+			response.addHeader("Access-Control-Expose-Headers", "Authorization");
+			response.addHeader("Authorization", "Bearer " + authResponse.getFirst());
+
+			return new ResponseEntity<>(formattedUser, HttpStatus.OK);
+		} catch (Exception e) {
+			// TODO: fazer o tratamento correto dos erros
+			return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
 		}
-		
-		/*TODO Não sei como tratar isso :( */
-		return (ResponseEntity<?>) ResponseEntity.status(HttpStatus.FORBIDDEN); 	
-		
 	}
 }

--- a/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/dtos/LoggedUserDto.java
+++ b/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/dtos/LoggedUserDto.java
@@ -1,0 +1,47 @@
+package br.com.codenation.errorcenter.dtos;
+
+public class LoggedUserDto {
+    private Long id;
+    private String name;
+    private String email;
+    private String tokenAccess;
+
+    public LoggedUserDto(Long id, String name, String email, String tokenAccess) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.tokenAccess = tokenAccess;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getTokenAccess() {
+        return tokenAccess;
+    }
+
+    public void setTokenAccess(String tokenAccess) {
+        this.tokenAccess = tokenAccess;
+    }
+}

--- a/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/dtos/UserLoginRequestBody.java
+++ b/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/dtos/UserLoginRequestBody.java
@@ -1,0 +1,6 @@
+package br.com.codenation.errorcenter.dtos;
+
+public class UserLoginRequestBody {
+    public String email;
+    public String password;
+}

--- a/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/repository/LogRepository.java
+++ b/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/repository/LogRepository.java
@@ -3,7 +3,9 @@ package br.com.codenation.errorcenter.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import br.com.codenation.errorcenter.models.Log;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface LogRepository extends JpaRepository<Log, Long>{
 
 }

--- a/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/security/JwtAuthenticationFilter.java
+++ b/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/security/JwtAuthenticationFilter.java
@@ -1,0 +1,25 @@
+package br.com.codenation.errorcenter.security;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends GenericFilterBean {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException, ExpiredJwtException {
+        Authentication authentication = JwtToken.validateAuthorizedRequest((HttpServletRequest) request);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/security/JwtToken.java
+++ b/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/security/JwtToken.java
@@ -1,0 +1,64 @@
+package br.com.codenation.errorcenter.security;
+
+import br.com.codenation.errorcenter.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.*;
+
+@Service
+public class JwtToken {
+    // TODO: esconder essa variável dentro das config vars do Heroku para não deixar exposta no código
+    private static final String JWT_LOCAL_SECRET = "4z6B8EbGdKgNjQnTqVsYv2x5A7C9FcHeKhPkRnUr";
+    private static final String TOKEN_ISSUER = "sherlog-api";
+    private static final String TOKEN_AUDIENCE = "sherlog-app";
+    // TOKEN_EXPIRATION_TIME calculado em milisegundos, definido para 10 segundos
+    private static final int TOKEN_EXPIRATION_TIME = 1000 * 60 * 60;
+    private static final String TOKEN_HEADER = "Authorization";
+    private static final String TOKEN_PREFIX = "Bearer";
+
+    private static UserRepository userRepository;
+
+    public static String addJwtToken(String userToken) {
+        String tokenId = UUID.randomUUID().toString();
+
+        String jwtToken = Jwts.builder()
+                .setId(tokenId)
+                .setIssuer(TOKEN_ISSUER)
+                .setAudience(TOKEN_AUDIENCE)
+                .setSubject(userToken)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + TOKEN_EXPIRATION_TIME))
+                .signWith(Keys.hmacShaKeyFor(JWT_LOCAL_SECRET.getBytes()))
+                .compact();
+
+        return jwtToken;
+    }
+
+    public static Authentication validateAuthorizedRequest(HttpServletRequest request) {
+        String authToken = request.getHeader(TOKEN_HEADER);
+
+        if (authToken != null) {
+            return validateJwtToken(authToken);
+        }
+
+        return null;
+    }
+
+    private static Authentication validateJwtToken(String userAuthToken) throws ExpiredJwtException {
+        String userToken = Jwts.parser()
+                .setSigningKey(Keys.hmacShaKeyFor(JWT_LOCAL_SECRET.getBytes()))
+                .parseClaimsJws(userAuthToken.replace(TOKEN_PREFIX, ""))
+                .getBody()
+                .getSubject();
+
+        return userToken != null
+                ? new UsernamePasswordAuthenticationToken(userToken, null, null)
+                : null;
+    }
+}

--- a/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/security/PasswordEncoder.java
+++ b/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/security/PasswordEncoder.java
@@ -1,4 +1,4 @@
-package br.com.codenation.errorcenter.utils;
+package br.com.codenation.errorcenter.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;

--- a/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/security/WebSecurityConfig.java
+++ b/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/security/WebSecurityConfig.java
@@ -1,0 +1,22 @@
+package br.com.codenation.errorcenter.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+    @Override
+    protected void configure(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.csrf().disable().authorizeRequests()
+                .antMatchers(HttpMethod.POST,"/user").permitAll()
+                .antMatchers(HttpMethod.POST,"/user/login").permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .addFilterBefore(new JwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/service/LogService.java
+++ b/backend/errorcenter/src/main/java/br/com/codenation/errorcenter/service/LogService.java
@@ -1,5 +1,27 @@
 package br.com.codenation.errorcenter.service;
 
-public class LogService {
+import br.com.codenation.errorcenter.models.Log;
+import br.com.codenation.errorcenter.repository.LogRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class LogService {
+    @Autowired
+    private LogRepository logRepository;
+
+    public List<?> findAll() {
+        return null;
+    }
+
+    public Optional<?> findById(long id) {
+        return Optional.empty();
+    }
+
+    public Log saveNewLog(Log log) {
+        return logRepository.save(log);
+    }
 }


### PR DESCRIPTION
Esse PR insere a autenticação por token JWT na nossa aplicação.

- JwtAuthenticationFilter: Criei um filtro que passará a verificar se o usuário está autenticado, isto é, se na header da requisição consta o token jwt, antes de chamar os endpoints;

- WebSecurityConfig: esse arquivo configura as páginas em que é necessário o usuário estar autenticado. Talvez seja necessário inserir uma white list com urls externas como a do swagger futuramente;

- CorsConfig: já que agora a verificação do token acontece antes dos acessos aos endpoints propriamente ditos as annotations @CrossOrigin presentes nos controllers só são acessadas depois da autenticação, o que estava causando problema de CORS. Para resolver, implementei uma configuração global com prioridade em cima de qualquer outra classe da aplicação;

- JwtToken: contém um método pra criar o jwt (baseado no token uuid random de cada usuário e com data de expiração de 1h) e outro pra validar o jwt;

- Package dto: adicionei arquivos pra formatar tanto os requests recebidos quando necessário, como o caso do request de login (que só contém usuário e senha), quanto os responses que também não devolverem todos os dados do banco (como o de login, que não deve passar a senha do usuário pro front);

- Complementei os métodos de login e cadastro de usuários implementados pela Jaque;

- Inseri métodos de getLogs e getLogsById apenas pra testar o fluxo do token passeando entre as requisições e testar a validade dele. Mas não está funcionando corretamente. 

Pendências: fazer um tratamento melhor dos erros e implementar secret key usado pra criar o jwt numa variável de ambiente do Heroku.

=)